### PR TITLE
Replace daemon-reexec with daemon-reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ WantedBy=default.target
 ```
 
 ```sh
-systemctl --user daemon-reexec
+systemctl --user daemon-reload
 systemctl --user enable pesu-attendance-bot.service --now
 ```
 


### PR DESCRIPTION
daemon-rexec is generally overkill with reload being preferred.  
snip from manpage:
> This command is of little use except for debugging and package upgrades. Sometimes, it might be helpful as a heavy-weight daemon-reload. While the daemon is being reexecuted, all sockets systemd listening on behalf of user configuration will stay accessible.

It's obvious that this isn't required for this particular instance.